### PR TITLE
:+1:'' ""のみの入力のときエラーを出るようにした。

### DIFF
--- a/src/lexer/tokenizer.c
+++ b/src/lexer/tokenizer.c
@@ -74,10 +74,26 @@ static bool	take_word_token(char **line, t_token *tail_token)
 	return (true);
 }
 
+bool	quotation_only_check(char *line)
+{
+	while (*line)
+	{
+		if (strncmp(line, "''", 2) == 0)
+			line += 2;
+		else if (strncmp(line, "\"\"", 2) == 0)
+			line += 2;
+		else
+			return (false);
+	}
+	return (true);
+}
+
 t_token	*tokenizer(char *line)
 {
 	t_token	head;
 
+	if (quotation_only_check(line))
+		return (put_tokenizer_error("Command '' not found"), NULL);
 	ft_memset(&head, 0, sizeof(t_token));
 	while (*line)
 	{

--- a/src/print/put_error2.c
+++ b/src/print/put_error2.c
@@ -16,7 +16,7 @@ void	put_tokenizer_error(char *str)
 {
 	ft_putstr_fd("minishell: tokenizer: ", STDERR_FILENO);
 	ft_putstr_fd(str, STDERR_FILENO);
-	ft_putstr_fd(str, STDERR_FILENO);
+	ft_putstr_fd("\n", STDERR_FILENO);
 }
 
 void	put_unexpected_token_error(char *token)


### PR DESCRIPTION
 - tokenizer.cにquotation_only_check関数をついか
 - put_error2.cのput_tokenizer_error(char *str)を修正